### PR TITLE
Octet conversion to numpy.int8 array

### DIFF
--- a/python/redhawk_source.py
+++ b/python/redhawk_source.py
@@ -44,6 +44,8 @@ class DTRecord(object):
             self.buffer_out = numpy.array(
                 bulkio_helpers.bulkioComplexToPythonComplexList(data_transfer.dataBuffer),
                 dtype=np_type)
+        elif np_type == numpy.int8:
+            self.buffer_out = numpy.fromstring(data_transfer.dataBuffer, dtype=np_type)
         else:
             self.buffer_out = numpy.array(data_transfer.dataBuffer, dtype=np_type)
 


### PR DESCRIPTION
The data buffer of packets coming from `dataOctet` ports are string literals in python, not lists.  Hence the usage of `numpy.fromstring` vs. `numpy.array`.